### PR TITLE
Fix dependency incompatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
   docker:
     name: Docker
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
     needs:
       - lint
       - check
@@ -62,6 +61,9 @@ jobs:
       uses: actions/checkout@v1
     - name: Login
       run: docker login docker.pkg.github.com -u bahlo -p "${{ secrets.GITHUB_TOKEN }}"
+    - name: Build docker container
+      if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags')
+      run: docker build -t docker.pkg.github.com/bahlo/ing-ynab/ing-ynab:branch .
     - name: Build and publish docker latest
       if: github.ref == 'refs/heads/main'
       run: |

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "packaging==20.7; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
         "pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
         "python-dotenv==0.15.0",
-        "requests==2.25.0",
+        "requests==2.25.1",
         "sepaxml==2.3.0",
         "six==1.15.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
         "text-unidecode==1.3",


### PR DESCRIPTION
This resolves a compatibility issue as we've upgraded to chardet=4.0.0 but requests 2.25.0 still required <4.

It also adds a docker build step to pull requests to catch these issues earlier.