### PR TITLE
Mark transactions as imported in YNAB

### DIFF
--- a/ing_ynab/ynab.py
+++ b/ing_ynab/ynab.py
@@ -1,7 +1,7 @@
 """
 Provides methods to work with the YNAB API.
 """
-from datetime import datetime
+from datetime import date
 from decimal import Decimal
 from typing import List, Optional, Dict
 from mt940.models import Transaction as FinTSTransaction
@@ -66,19 +66,24 @@ class YNABClient:
             # ING sometimes adds transactions that are dated to the future.
             # YNAB doesn't support this, so since the transaction already
             # happened anyway, we're overriding the date.
-            date = data["date"]
-            if date > datetime.now():
-                date = datetime.now()
+            transaction_date = data["date"]
+            if transaction_date > date.today():
+                transaction_date = date.today()
+
+            milliunits_amount = int(data["amount"].amount * Decimal("1000.0"))
+            similar_transactions = [x for x in transformed if date.fromisoformat(x["date"]) == transaction_date and x["amount"] == milliunits_amount]
+            occurence = len(similar_transactions) + 1
 
             transformed.append(
                 {
                     "account_id": self.account_id,
-                    "date": date.isoformat(),
-                    "amount": int(data["amount"].amount * Decimal("1000.0")),
+                    "date": transaction_date.isoformat(),
+                    "amount": milliunits_amount,
                     "payee_name": data["applicant_name"],
                     "cleared": "cleared",
                     "memo": data["purpose"],
                     "flag_color": self.flag_color,
+                    "import_id": f"YNAB:{milliunits_amount}:{transaction_date.isoformat()}:{occurence}",
                 }
             )
         return transformed

--- a/ing_ynab/ynab.py
+++ b/ing_ynab/ynab.py
@@ -71,8 +71,16 @@ class YNABClient:
                 transaction_date = date.today()
 
             milliunits_amount = int(data["amount"].amount * Decimal("1000.0"))
-            similar_transactions = [x for x in transformed if date.fromisoformat(x["date"]) == transaction_date and x["amount"] == milliunits_amount]
+            similar_transactions = [
+                x
+                for x in transformed
+                if date.fromisoformat(x["date"]) == transaction_date
+                and x["amount"] == milliunits_amount
+            ]
             occurence = len(similar_transactions) + 1
+            import_id = (
+                f"YNAB:{milliunits_amount}:{transaction_date.isoformat()}:{occurence}"
+            )
 
             transformed.append(
                 {
@@ -83,7 +91,7 @@ class YNABClient:
                     "cleared": "cleared",
                     "memo": data["purpose"],
                     "flag_color": self.flag_color,
-                    "import_id": f"YNAB:{milliunits_amount}:{transaction_date.isoformat()}:{occurence}",
+                    "import_id": import_id,
                 }
             )
         return transformed

--- a/tests/test_ynab.py
+++ b/tests/test_ynab.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import date
 from mt940.models import Transaction, Amount
 
 from ing_ynab.ynab import YNABClient
@@ -15,7 +15,7 @@ class TestTransformTransactions(unittest.TestCase):
             Transaction(
                 [],
                 data={
-                    "date": datetime.fromisoformat("2020-01-11T13:20:00"),
+                    "date": date.fromisoformat("2020-01-11"),
                     "applicant_name": "foo",
                     "purpose": "bar",
                     "amount": Amount("42.24", "C"),
@@ -24,7 +24,7 @@ class TestTransformTransactions(unittest.TestCase):
             Transaction(
                 [],
                 data={
-                    "date": datetime.fromisoformat("2020-08-11T13:20:00"),
+                    "date": date.fromisoformat("2020-08-11"),
                     "applicant_name": "bar",
                     "purpose": "baz",
                     "amount": Amount("1337", "D"),
@@ -36,24 +36,55 @@ class TestTransformTransactions(unittest.TestCase):
         self.assertEqual(
             {
                 "account_id": account_id,
-                "date": "2020-01-11T13:20:00",
+                "date": "2020-01-11",
                 "amount": 42240,
                 "payee_name": "foo",
                 "cleared": "cleared",
                 "memo": "bar",
                 "flag_color": flag_color,
+                "import_id": "YNAB:42240:2020-01-11:1",
             },
             transformed[0],
         )
         self.assertEqual(
             {
                 "account_id": account_id,
-                "date": "2020-08-11T13:20:00",
+                "date": "2020-08-11",
                 "amount": -1337000,
                 "payee_name": "bar",
                 "cleared": "cleared",
                 "memo": "baz",
                 "flag_color": flag_color,
+                "import_id": "YNAB:-1337000:2020-08-11:1",
             },
             transformed[1],
         )
+
+    def test_correct_import_id_occurence(self):
+        ynab_client = YNABClient("", "abcdef", "")
+
+        transactions = [
+            Transaction(
+                [],
+                data={
+                    "date": date.fromisoformat("2020-06-13"),
+                    "applicant_name": "foo",
+                    "purpose": "bar",
+                    "amount": Amount("42.24", "D"),
+                },
+            ),
+            Transaction(
+                [],
+                data={
+                    "date": date.fromisoformat("2020-06-13"),
+                    "applicant_name": "foo",
+                    "purpose": "bar",
+                    "amount": Amount("42.24", "D"),
+                },
+            ),
+        ]
+        transformed = ynab_client.transform_transactions(transactions)
+
+        self.assertEqual(2, len(transformed))
+        self.assertEqual(transformed[0]["import_id"], "YNAB:-42240:2020-06-13:1")
+        self.assertEqual(transformed[1]["import_id"], "YNAB:-42240:2020-06-13:2")


### PR DESCRIPTION
This allows for transaction matching and makes the tool work like the official direct and file import features from YNAB. The format matches the official one, as it is described in their API docs. In the end it will look like this in the YNAB UI:

<img width="234" alt="Bildschirmfoto 2021-06-13 um 18 23 23" src="https://user-images.githubusercontent.com/770596/121815068-aca99680-cc74-11eb-83ff-e847088a7066.png">

Unmatched transactions will be added like before, items that already have a matching transaction will be linked to the existing one. If YNAB ever officially starts supporting direct import from ING there should be no duplicates either, as we adhere to their ID format.

In theory this would also allow the tool to drop the state file - transactions with the same import id won't be added again, I tested this by re-running the tool after deleting the state file. If you want I can remove this logic, but I wanted to start with a minimal change and hear feedback from you.

I also switched the datetime usage to date, as I noticed that the returned values from the FinTS lib are Date objects, not Datetime ones.

Closes #117.