### PR TITLE
Revert "Use pipenv for dependabot"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: pipenv
+  - package-ecosystem: pip
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Reverts bahlo/ing-ynab#154

> For package managers such as pipenv and poetry, you need to use the pip YAML value. For example, if you use poetry to manage your Python dependencies and want Dependabot to monitor your dependency manifest file for new versions, use package-ecosystem: "pip" in your dependabot.yml file.

